### PR TITLE
Refactor CloudServiceCard

### DIFF
--- a/src/lib/CloudServiceCard.svelte
+++ b/src/lib/CloudServiceCard.svelte
@@ -1,12 +1,11 @@
 <script lang="ts" context="module">
 	export interface CloudServiceEvent {
 		serviceIdx: number;
-		requirementIdx?: number;
+		requirements: any[];
 	}
 
 	export interface CloudServiceEventMap {
-		'add-requirement': CloudServiceEvent;
-		'remove-requirement': CloudServiceEvent;
+		'add-requirements': CloudServiceEvent;
 	}
 </script>
 
@@ -19,6 +18,10 @@
 		CardHeader,
 		CardSubtitle,
 		CardText,
+		Dropdown,
+		DropdownItem,
+		DropdownMenu,
+		DropdownToggle,
 		ListGroup,
 		ListGroupItem
 	} from 'sveltestrap';
@@ -31,6 +34,20 @@
 	export let service: CloudService;
 
 	const dispatch = createEventDispatcher<CloudServiceEventMap>();
+
+	var available_requirements = Array.from($requirements.values())
+	let selected_requirements = []
+
+	function handleAdd(requirement) {
+		selected_requirements.push(requirement)
+		selected_requirements = selected_requirements;
+	}
+
+	function handleRemove(requirement) {
+		selected_requirements.splice(requirement)
+		selected_requirements = selected_requirements;
+	}
+
 </script>
 
 <Card class="mb-3 me-3">
@@ -41,30 +58,29 @@
 				{service.description}
 			</p>
 		</CardText>
-		<CardSubtitle>Requirements in Scope</CardSubtitle>
+		<CardSubtitle>Selected Requirements</CardSubtitle>
 		<CardText>
-			<ListGroup flush>
-				{#each service.requirements?.requirementIds ?? [] as reqId, reqIdx}
+			<ListGroup>
+				{#each selected_requirements as req}
 					<ListGroupItem class="d-flex">
-						<div class="ms-2 me-auto">
-							{reqId}: {$requirements.get(reqId)?.name}
-						</div>
-
-						<Button
-							on:click={(e) =>
-								dispatch('remove-requirement', { serviceIdx: 0, requirementIdx: reqIdx })}
-						>
+						{req.id}: {req.name}
+						<Button on:click={(e) => handleRemove(req)}>
 							<Fa icon={faTrash} />
 						</Button>
 					</ListGroupItem>
 				{/each}
 			</ListGroup>
-			<Button class="mt-2" on:click={(e) => dispatch('add-requirement', { serviceIdx: 0 })}>
-				<Fa icon={faPlus} />
-			</Button>
 		</CardText>
-		<Button disabled>
-			<Fa icon={faTrash} />
+		<Dropdown>
+			<DropdownToggle caret>Add</DropdownToggle>
+			<DropdownMenu>
+				{#each available_requirements as req, reqIdx}
+					<DropdownItem on:click={(e) => handleAdd(req)}>{req.id}: {req.name}</DropdownItem>
+				{/each}
+			</DropdownMenu>
+		</Dropdown>
+		<Button color=primary on:click={(e) => dispatch('add-requirements', {serviceIdx: 0, requirements: selected_requirements})}>
+			Update
 		</Button>
 	</CardBody>
 	<CardFooter>{service.id}</CardFooter>

--- a/src/routes/cloud/index.svelte
+++ b/src/routes/cloud/index.svelte
@@ -1,10 +1,6 @@
 <script lang="ts" context="module">
 	import { requirements } from '$lib/stores';
-	import {
-		listCloudServices,
-		listRequirements,
-		updateCloudService
-	} from '$lib/orchestrator';
+	import { listCloudServices, listRequirements, updateCloudService } from '$lib/orchestrator';
 	import type { CloudService } from '$lib/orchestrator';
 
 	/**
@@ -50,18 +46,27 @@
 
 	export let services: CloudService[];
 
-	function addRequirements(e: CustomEvent<CloudServiceEvent>) {
-		let reqIds = []
-		e.detail.requirements.forEach(req => {
-			reqIds.push(req.id)
-		});
+	function addRequirement(e: CustomEvent<CloudServiceEvent>) {
+		const reqId = e.detail.requirementId;
+
+		var requirements = services[e.detail.serviceIdx].requirements?.requirementIds ?? [];
 
 		if (services[e.detail.serviceIdx].requirements == null) {
 			services[e.detail.serviceIdx].requirements = { requirementIds: [] };
 		}
 
-		services[e.detail.serviceIdx].requirements.requirementIds = reqIds;
+		services[e.detail.serviceIdx].requirements.requirementIds = [...requirements, reqId];
+	}
 
+	function removeRequirement(e: CustomEvent<CloudServiceEvent>) {
+		var requirements = services[e.detail.serviceIdx].requirements.requirementIds;
+
+		services[e.detail.serviceIdx].requirements.requirementIds = requirements.filter(
+			(_r, idx) => idx != e.detail.requirementIdx
+		);
+	}
+
+	function save(e: CustomEvent<CloudServiceEvent>) {
 		updateCloudService(services[e.detail.serviceIdx]);
 	}
 </script>
@@ -76,7 +81,9 @@ The following page can be used to configure Cloud services.
 			<Col>
 				<CloudServiceCard
 					{service}
-					on:add-requirements={addRequirements}
+					on:add-requirement={addRequirement}
+					on:remove-requirement={removeRequirement}
+					on:save={save}
 				/>
 			</Col>
 		{/each}

--- a/src/routes/cloud/index.svelte
+++ b/src/routes/cloud/index.svelte
@@ -50,30 +50,19 @@
 
 	export let services: CloudService[];
 
-	function removeRequirement(e: CustomEvent<CloudServiceEvent>) {
-		var requirements = services[e.detail.serviceIdx].requirements.requirementIds;
+	function addRequirements(e: CustomEvent<CloudServiceEvent>) {
+		let reqIds = []
+		e.detail.requirements.forEach(req => {
+			reqIds.push(req.id)
+		});
 
-		services[e.detail.serviceIdx].requirements.requirementIds = requirements.filter(
-			(_r, idx) => idx != e.detail.requirementIdx
-		);
+		if (services[e.detail.serviceIdx].requirements == null) {
+			services[e.detail.serviceIdx].requirements = { requirementIds: [] };
+		}
+
+		services[e.detail.serviceIdx].requirements.requirementIds = reqIds;
 
 		updateCloudService(services[e.detail.serviceIdx]);
-	}
-
-	function addRequirement(e: CustomEvent<CloudServiceEvent>) {
-		const reqId = prompt('Enter a requirement id');
-
-		if (reqId != '') {
-			var requirements = services[e.detail.serviceIdx].requirements?.requirementIds ?? [];
-
-			if (services[e.detail.serviceIdx].requirements == null) {
-				services[e.detail.serviceIdx].requirements = { requirementIds: [] };
-			}
-
-			services[e.detail.serviceIdx].requirements.requirementIds = [...requirements, reqId];
-
-			updateCloudService(services[e.detail.serviceIdx]);
-		}
 	}
 </script>
 
@@ -87,8 +76,7 @@ The following page can be used to configure Cloud services.
 			<Col>
 				<CloudServiceCard
 					{service}
-					on:add-requirement={addRequirement}
-					on:remove-requirement={removeRequirement}
+					on:add-requirements={addRequirements}
 				/>
 			</Col>
 		{/each}


### PR DESCRIPTION
This PR addresses an issue with the addition of requirements to cloud services: currently a requirement id has to be added correctly in a free text field which is error-prone. With this change, there is a dropdown menu for the available requirements. Also, an update button is added such that a list of requirements is updated once instead of calling the UpdateCloudService method everytime a new requirement is added.
In the future we should consider making unique requirements modifiable instead of updating the whole cloud service