### PR TITLE
Fixed assessment result filtered by cloud service ID

### DIFF
--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -142,7 +142,7 @@ export async function listAssessmentResults(): Promise<AssessmentResult[]> {
  * @returns an array of {@link AssessmentResult}s.
  */
 export async function listCloudServiceAssessmentResults(serviceId: string, fetch = window.fetch): Promise<AssessmentResult[]> {
-    const apiUrl = clouditorize(`/v1/orchestrator/cloud_services/${serviceId}/assessment_results?pageSize=100`);
+    const apiUrl = clouditorize(`/v1/orchestrator/assessment_results?pageSize=100&filteredCloudServiceId=${serviceId}`);
 
     return fetch(apiUrl, {
         method: 'GET',


### PR DESCRIPTION
We changed the way we retrieve assessment results in https://github.com/clouditor/clouditor/pull/877 and did not change the UI. This is a hot fix for that.